### PR TITLE
Bugfix: Multiple Aggregations on same IU

### DIFF
--- a/p2c.cpp
+++ b/p2c.cpp
@@ -86,6 +86,8 @@ struct IUSet {
    explicit IUSet(const vector<IU*>& vv) {
       v = vv;
       sort(v.begin(), v.end());
+      // check that there are no duplicates
+      assert(adjacent_find(v.begin(), v.end()) == v.end());
    }
 
    // iterate over IUs


### PR DESCRIPTION
Consider a query that performs multiple aggregations on the same attribute/IU:
```
  auto o = make_unique<Scan>("orders");
  IU *od = o->getIU("o_orderdate");
  IU *op = o->getIU("o_totalprice");

  auto sel = make_unique<Selection>(
      std::move(o), makeCallExp("std::less()", od, stringToType<Date>("1995-03-15", 10).value));
  auto gb = make_unique<GroupBy>(std::move(sel), IUSet());
  gb->addSum("sum", op);
  gb->addMin("min", op);

  IU *min_ = gb->getIU("min");
  IU *sum_ = gb->getIU("sum");
  produceAndPrint(std::move(gb), {min_, sum_});
```
Currently, compiling this query leads to the following error because of an erroneous conversion from inputIUs() to IUSet:
```
 Error message
In file included from queryFrame.cpp:38:
./gen.cpp:6:17: error: redefinition of 'o_totalprice4'
        Numeric o_totalprice4 = db.orders.o_totalprice[i];
                ^
./gen.cpp:5:17: note: previous definition is here
        Numeric o_totalprice4 = db.orders.o_totalprice[i];
```
This leads to Scan calling provideIU twice on the same IU and thus a redefinition of o_totalprice4.

Proposed fix: Directly create an IUSet from vector of aggregation functions
```
IUSet inputIUs() {
      IUSet v;
      for (auto&[fn, inputIU, resultIU] : aggs)
         if (inputIU)
            v.add(inputIU);
      return v;
   }
```